### PR TITLE
Feature/pointer lock device event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 target
 Cargo.lock
 *.patch
-smithay-local/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 target
 Cargo.lock
 *.patch
+smithay-local/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 !.claude/skills/
 target
 Cargo.lock
+*.patch

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ tracing = "0.1"
 
 [profile.release]
 lto = true
+
+[patch."https://github.com/emskin/smithay.git"]
+smithay = { path = "smithay-local" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,3 @@ tracing = "0.1"
 
 [profile.release]
 lto = true
-
-[patch."https://github.com/emskin/smithay.git"]
-smithay = { path = "smithay-local" }

--- a/crates/emskin/src/handlers/pointer_constraints.rs
+++ b/crates/emskin/src/handlers/pointer_constraints.rs
@@ -24,7 +24,7 @@ impl PointerConstraintsHandler for EmskinState {
                     constraint.activate();
                     if matches!(&*constraint, PointerConstraint::Locked(_)) {
                         if let Some(backend) = self.backend.as_ref() {
-                            let _ = backend.window().set_cursor_grab(CursorGrabMode::Locked);
+                            let _ = backend.window().set_cursor_grab(CursorGrabMode::Confined);
                             self.cursor.host_cursor_locked = true;
                         }
                     }

--- a/crates/emskin/src/handlers/pointer_constraints.rs
+++ b/crates/emskin/src/handlers/pointer_constraints.rs
@@ -8,7 +8,9 @@
 use smithay::input::pointer::PointerHandle;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::utils::{Logical, Point};
-use smithay::wayland::pointer_constraints::{with_pointer_constraint, PointerConstraint, PointerConstraintsHandler};
+use smithay::wayland::pointer_constraints::{
+    with_pointer_constraint, PointerConstraint, PointerConstraintsHandler,
+};
 use smithay::{delegate_pointer_constraints, delegate_relative_pointer};
 use winit_crate::window::CursorGrabMode;
 

--- a/crates/emskin/src/handlers/pointer_constraints.rs
+++ b/crates/emskin/src/handlers/pointer_constraints.rs
@@ -8,8 +8,9 @@
 use smithay::input::pointer::PointerHandle;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::utils::{Logical, Point};
-use smithay::wayland::pointer_constraints::{with_pointer_constraint, PointerConstraintsHandler};
+use smithay::wayland::pointer_constraints::{with_pointer_constraint, PointerConstraint, PointerConstraintsHandler};
 use smithay::{delegate_pointer_constraints, delegate_relative_pointer};
+use winit_crate::window::CursorGrabMode;
 
 use crate::EmskinState;
 
@@ -19,6 +20,12 @@ impl PointerConstraintsHandler for EmskinState {
             with_pointer_constraint(surface, pointer, |constraint| {
                 if let Some(constraint) = constraint {
                     constraint.activate();
+                    if matches!(&*constraint, PointerConstraint::Locked(_)) {
+                        if let Some(backend) = self.backend.as_ref() {
+                            let _ = backend.window().set_cursor_grab(CursorGrabMode::Locked);
+                            self.cursor.host_cursor_locked = true;
+                        }
+                    }
                 }
             });
         }

--- a/crates/emskin/src/handlers/pointer_constraints.rs
+++ b/crates/emskin/src/handlers/pointer_constraints.rs
@@ -24,7 +24,7 @@ impl PointerConstraintsHandler for EmskinState {
                     constraint.activate();
                     if matches!(&*constraint, PointerConstraint::Locked(_)) {
                         if let Some(backend) = self.backend.as_ref() {
-                            let _ = backend.window().set_cursor_grab(CursorGrabMode::Confined);
+                            let _ = backend.window().set_cursor_grab(CursorGrabMode::Locked);
                             self.cursor.host_cursor_locked = true;
                         }
                     }

--- a/crates/emskin/src/input.rs
+++ b/crates/emskin/src/input.rs
@@ -8,7 +8,7 @@ use smithay::{
         pointer::{AxisFrame, ButtonEvent, MotionEvent, RelativeMotionEvent},
     },
     reexports::wayland_server::Resource,
-    utils::SERIAL_COUNTER,
+    utils::{Logical, Point, SERIAL_COUNTER},
     wayland::{
         pointer_constraints::{with_pointer_constraint, PointerConstraint},
         seat::WaylandFocus,
@@ -101,6 +101,7 @@ impl EmskinState {
                 let Some(output_geo) = self.workspace.active_space.output_geometry(output) else {
                     return;
                 };
+                let output_scale = output.current_scale().fractional_scale();
                 let Some(pointer) = self.seat.get_pointer() else {
                     return;
                 };
@@ -176,10 +177,23 @@ impl EmskinState {
 
                 if pointer_locked {
                     pointer.frame(self);
-                    if !self.cursor.host_cursor_locked {
-                        if let Some(backend) = self.backend.as_ref() {
-                            let _ = backend.window().set_cursor_grab(CursorGrabMode::Confined);
+                    if let Some(backend) = self.backend.as_ref() {
+                        let window = backend.window();
+                        if !self.cursor.host_cursor_locked {
+                            let _ = window.set_cursor_grab(CursorGrabMode::Locked);
                             self.cursor.host_cursor_locked = true;
+                        }
+                        let size = window.inner_size();
+                        let center = winit_crate::dpi::PhysicalPosition::new(
+                            (size.width / 2) as i32,
+                            (size.height / 2) as i32,
+                        );
+                        if window.set_cursor_position(center).is_ok() {
+                            let cx = (size.width / 2) as f64 / output_scale;
+                            let cy = (size.height / 2) as f64 / output_scale;
+                            let center_logical: Point<f64, Logical> =
+                                (output_geo.loc.x as f64 + cx, output_geo.loc.y as f64 + cy).into();
+                            self.cursor.force_raw_location(center_logical);
                         }
                     }
                     return;

--- a/crates/emskin/src/input.rs
+++ b/crates/emskin/src/input.rs
@@ -8,7 +8,7 @@ use smithay::{
         pointer::{AxisFrame, ButtonEvent, MotionEvent, RelativeMotionEvent},
     },
     reexports::wayland_server::Resource,
-    utils::{Logical, Point, SERIAL_COUNTER},
+    utils::SERIAL_COUNTER,
     wayland::{
         pointer_constraints::{with_pointer_constraint, PointerConstraint},
         seat::WaylandFocus,
@@ -101,7 +101,6 @@ impl EmskinState {
                 let Some(output_geo) = self.workspace.active_space.output_geometry(output) else {
                     return;
                 };
-                let output_scale = output.current_scale().fractional_scale();
                 let Some(pointer) = self.seat.get_pointer() else {
                     return;
                 };
@@ -177,23 +176,10 @@ impl EmskinState {
 
                 if pointer_locked {
                     pointer.frame(self);
-                    if let Some(backend) = self.backend.as_ref() {
-                        let window = backend.window();
-                        if !self.cursor.host_cursor_locked {
-                            let _ = window.set_cursor_grab(CursorGrabMode::Locked);
+                    if !self.cursor.host_cursor_locked {
+                        if let Some(backend) = self.backend.as_ref() {
+                            let _ = backend.window().set_cursor_grab(CursorGrabMode::Confined);
                             self.cursor.host_cursor_locked = true;
-                        }
-                        let size = window.inner_size();
-                        let center = winit_crate::dpi::PhysicalPosition::new(
-                            (size.width / 2) as i32,
-                            (size.height / 2) as i32,
-                        );
-                        if window.set_cursor_position(center).is_ok() {
-                            let cx = (size.width / 2) as f64 / output_scale;
-                            let cy = (size.height / 2) as f64 / output_scale;
-                            let center_logical: Point<f64, Logical> =
-                                (output_geo.loc.x as f64 + cx, output_geo.loc.y as f64 + cy).into();
-                            self.cursor.force_raw_location(center_logical);
                         }
                     }
                     return;

--- a/crates/emskin/src/input.rs
+++ b/crates/emskin/src/input.rs
@@ -8,12 +8,13 @@ use smithay::{
         pointer::{AxisFrame, ButtonEvent, MotionEvent, RelativeMotionEvent},
     },
     reexports::wayland_server::Resource,
-    utils::SERIAL_COUNTER,
+    utils::{Logical, Point, SERIAL_COUNTER},
     wayland::{
         pointer_constraints::{with_pointer_constraint, PointerConstraint},
         seat::WaylandFocus,
     },
 };
+use winit_crate::window::CursorGrabMode;
 
 use crate::state::EmskinState;
 
@@ -48,8 +49,7 @@ impl EmskinState {
                             }
                         }
 
-                        (modifiers.ctrl
-                            && matches!(key, keysyms::KEY_x | keysyms::KEY_c | keysyms::KEY_j))
+                        (modifiers.ctrl && matches!(key, keysyms::KEY_x | keysyms::KEY_c))
                             || (modifiers.alt && key == keysyms::KEY_x)
                     },
                 );
@@ -99,6 +99,7 @@ impl EmskinState {
                 let Some(output_geo) = self.workspace.active_space.output_geometry(output) else {
                     return;
                 };
+                let output_scale = output.current_scale().fractional_scale();
                 let Some(pointer) = self.seat.get_pointer() else {
                     return;
                 };
@@ -174,7 +175,34 @@ impl EmskinState {
 
                 if pointer_locked {
                     pointer.frame(self);
+                    if let Some(backend) = self.backend.as_ref() {
+                        let window = backend.window();
+                        if !self.cursor.host_cursor_locked {
+                            let _ = window.set_cursor_grab(CursorGrabMode::Locked);
+                            self.cursor.host_cursor_locked = true;
+                        }
+                        let size = window.inner_size();
+                        let center = winit_crate::dpi::PhysicalPosition::new(
+                            (size.width / 2) as i32,
+                            (size.height / 2) as i32,
+                        );
+                        if window.set_cursor_position(center).is_ok() {
+                            let cx = (size.width / 2) as f64 / output_scale;
+                            let cy = (size.height / 2) as f64 / output_scale;
+                            let center_logical: Point<f64, Logical> = (
+                                output_geo.loc.x as f64 + cx,
+                                output_geo.loc.y as f64 + cy,
+                            )
+                                .into();
+                            self.cursor.force_raw_location(center_logical);
+                        }
+                    }
                     return;
+                } else if self.cursor.host_cursor_locked {
+                    if let Some(backend) = self.backend.as_ref() {
+                        let _ = backend.window().set_cursor_grab(CursorGrabMode::None);
+                    }
+                    self.cursor.host_cursor_locked = false;
                 }
 
                 let serial = SERIAL_COUNTER.next_serial();

--- a/crates/emskin/src/input.rs
+++ b/crates/emskin/src/input.rs
@@ -49,6 +49,8 @@ impl EmskinState {
                             }
                         }
 
+                        state.cursor.last_modifiers = *modifiers;
+
                         (modifiers.ctrl && matches!(key, keysyms::KEY_x | keysyms::KEY_c))
                             || (modifiers.alt && key == keysyms::KEY_x)
                     },
@@ -189,11 +191,8 @@ impl EmskinState {
                         if window.set_cursor_position(center).is_ok() {
                             let cx = (size.width / 2) as f64 / output_scale;
                             let cy = (size.height / 2) as f64 / output_scale;
-                            let center_logical: Point<f64, Logical> = (
-                                output_geo.loc.x as f64 + cx,
-                                output_geo.loc.y as f64 + cy,
-                            )
-                                .into();
+                            let center_logical: Point<f64, Logical> =
+                                (output_geo.loc.x as f64 + cx, output_geo.loc.y as f64 + cy).into();
                             self.cursor.force_raw_location(center_logical);
                         }
                     }

--- a/crates/emskin/src/input.rs
+++ b/crates/emskin/src/input.rs
@@ -48,7 +48,8 @@ impl EmskinState {
                             }
                         }
 
-                        (modifiers.ctrl && matches!(key, keysyms::KEY_x | keysyms::KEY_c))
+                        (modifiers.ctrl
+                            && matches!(key, keysyms::KEY_x | keysyms::KEY_c | keysyms::KEY_j))
                             || (modifiers.alt && key == keysyms::KEY_x)
                     },
                 );

--- a/crates/emskin/src/state/cursor.rs
+++ b/crates/emskin/src/state/cursor.rs
@@ -19,6 +19,7 @@
 //!    correct under a pointer lock, while `pointer.current_location()`
 //!    would freeze.
 
+use smithay::input::keyboard::ModifiersState;
 use smithay::input::pointer::CursorImageStatus;
 use smithay::reexports::wayland_server::Resource;
 use smithay::utils::{Logical, Point};
@@ -32,6 +33,10 @@ pub struct CursorState {
     /// coords. `None` on first event.
     last_raw_loc: Option<Point<f64, Logical>>,
     pub host_cursor_locked: bool,
+    pub last_modifiers: ModifiersState,
+    /// Consecutive ticks with the same non-empty pressed-keys set and
+    /// active modifiers — used to detect stuck modifier keys.
+    pub pressed_same_ticks: u32,
 }
 
 impl Default for CursorState {
@@ -41,6 +46,8 @@ impl Default for CursorState {
             changed: false,
             last_raw_loc: None,
             host_cursor_locked: false,
+            last_modifiers: ModifiersState::default(),
+            pressed_same_ticks: 0,
         }
     }
 }

--- a/crates/emskin/src/state/cursor.rs
+++ b/crates/emskin/src/state/cursor.rs
@@ -31,6 +31,7 @@ pub struct CursorState {
     /// Last raw absolute pointer location from the host, in compositor
     /// coords. `None` on first event.
     last_raw_loc: Option<Point<f64, Logical>>,
+    pub host_cursor_locked: bool,
 }
 
 impl Default for CursorState {
@@ -39,6 +40,7 @@ impl Default for CursorState {
             status: CursorImageStatus::default_named(),
             changed: false,
             last_raw_loc: None,
+            host_cursor_locked: false,
         }
     }
 }
@@ -103,6 +105,10 @@ impl CursorState {
             Some(prev) => new_abs - prev,
             None => Point::default(),
         }
+    }
+
+    pub fn force_raw_location(&mut self, pos: Point<f64, Logical>) {
+        self.last_raw_loc = Some(pos);
     }
 }
 

--- a/crates/emskin/src/tick.rs
+++ b/crates/emskin/src/tick.rs
@@ -1,7 +1,9 @@
 //! Event loop tick — the per-frame idle callback for the compositor.
 
+use smithay::backend::input::KeyState;
+use smithay::input::keyboard::{FilterResult, ModifiersState};
 use smithay::reexports::wayland_server::Resource;
-use smithay::utils::IsAlive;
+use smithay::utils::{IsAlive, SERIAL_COUNTER};
 use smithay::wayland::{
     pointer_constraints::{with_pointer_constraint, PointerConstraint},
     seat::WaylandFocus,
@@ -62,9 +64,7 @@ pub fn event_loop_tick(state: &mut EmskinState) {
         if let Some(pointer) = state.seat.get_pointer() {
             if let Some(focused) = pointer.current_focus() {
                 still_locked = with_pointer_constraint(&focused, &pointer, |c| {
-                    c.is_some_and(|c| {
-                        matches!(&*c, PointerConstraint::Locked(_)) && c.is_active()
-                    })
+                    c.is_some_and(|c| matches!(&*c, PointerConstraint::Locked(_)) && c.is_active())
                 });
             }
         }
@@ -502,13 +502,11 @@ fn process_workspace_actions(state: &mut EmskinState) {
             WorkspaceAction::Activate(id) => {
                 state.switch_workspace(id);
             }
-            WorkspaceAction::Remove(id) => {
-                if id != state.workspace.active_id {
-                    state.destroy_workspace(id);
-                    state
-                        .ipc
-                        .send(OutgoingMessage::WorkspaceDestroyed { workspace_id: id });
-                }
+            WorkspaceAction::Remove(id) if id != state.workspace.active_id => {
+                state.destroy_workspace(id);
+                state
+                    .ipc
+                    .send(OutgoingMessage::WorkspaceDestroyed { workspace_id: id });
             }
             _ => {} // Deactivate / CreateWorkspace: future extension
         }
@@ -676,5 +674,44 @@ fn cleanup_dead_dialogs(state: &mut EmskinState) {
             keyboard.set_focus(state, target, serial);
             tracing::debug!("focus returned to Emacs after dialog destroy");
         }
+    }
+
+    // Release stuck modifier keys (e.g. Ctrl held but release
+    // event lost during focus disruption).
+    let mods = state.cursor.last_modifiers;
+    if (mods.ctrl || mods.alt || mods.logo || mods.shift) && !state.cursor.host_cursor_locked {
+        if let Some(keyboard) = state.seat.get_keyboard() {
+            let pressed = keyboard.pressed_keys();
+            if pressed.is_empty() {
+                state.cursor.pressed_same_ticks = 0;
+            } else {
+                let count = pressed.len();
+                let prev = state.cursor.pressed_same_ticks & 0xFFFF;
+                let prev_count = (state.cursor.pressed_same_ticks >> 16) as usize;
+                if prev_count == count {
+                    state.cursor.pressed_same_ticks = ((count as u32) << 16) | (prev + 1);
+                } else {
+                    state.cursor.pressed_same_ticks = ((count as u32) << 16) | 1;
+                }
+                if state.cursor.pressed_same_ticks & 0xFFFF > 60 {
+                    let time = state.start_time.elapsed().as_millis() as u32;
+                    for keycode in pressed {
+                        let serial = SERIAL_COUNTER.next_serial();
+                        keyboard.input::<(), _>(
+                            state,
+                            keycode,
+                            KeyState::Released,
+                            serial,
+                            time,
+                            |_, _, _| FilterResult::Forward,
+                        );
+                    }
+                    state.cursor.pressed_same_ticks = 0;
+                    state.cursor.last_modifiers = ModifiersState::default();
+                }
+            }
+        }
+    } else {
+        state.cursor.pressed_same_ticks = 0;
     }
 }

--- a/crates/emskin/src/tick.rs
+++ b/crates/emskin/src/tick.rs
@@ -2,7 +2,11 @@
 
 use smithay::reexports::wayland_server::Resource;
 use smithay::utils::IsAlive;
-use smithay::wayland::seat::WaylandFocus;
+use smithay::wayland::{
+    pointer_constraints::{with_pointer_constraint, PointerConstraint},
+    seat::WaylandFocus,
+};
+use winit_crate::window::CursorGrabMode;
 
 use crate::ipc::OutgoingMessage;
 use crate::state::EmskinState;
@@ -52,6 +56,25 @@ pub fn event_loop_tick(state: &mut EmskinState) {
     cleanup_dead_apps(state);
     // --- Clean up destroyed floating dialogs ---
     cleanup_dead_dialogs(state);
+
+    if state.cursor.host_cursor_locked {
+        let mut still_locked = false;
+        if let Some(pointer) = state.seat.get_pointer() {
+            if let Some(focused) = pointer.current_focus() {
+                still_locked = with_pointer_constraint(&focused, &pointer, |c| {
+                    c.is_some_and(|c| {
+                        matches!(&*c, PointerConstraint::Locked(_)) && c.is_active()
+                    })
+                });
+            }
+        }
+        if !still_locked {
+            if let Some(backend) = state.backend.as_ref() {
+                let _ = backend.window().set_cursor_grab(CursorGrabMode::None);
+            }
+            state.cursor.host_cursor_locked = false;
+        }
+    }
 
     // --- Dispatch incoming IPC messages from Emacs ---
     if let Some(msgs) = state.ipc.recv_all() {

--- a/crates/emskin/src/winit.rs
+++ b/crates/emskin/src/winit.rs
@@ -556,26 +556,6 @@ pub fn init_winit(
                 }
                 state.needs_redraw = true;
             }
-            WinitEvent::DeviceEvent(winit_crate::event::DeviceEvent::MouseMotion {
-                delta: (dx, dy),
-            }) if state.cursor.host_cursor_locked => {
-                if let Some(pointer) = state.seat.get_pointer() {
-                    let focus = pointer
-                        .current_focus()
-                        .map(|surface| (surface, pointer.current_location()));
-                    pointer.relative_motion(
-                        state,
-                        focus,
-                            &smithay::input::pointer::RelativeMotionEvent {
-                                delta: (dx, dy).into(),
-                                delta_unaccel: (dx, dy).into(),
-                                utime: state.start_time.elapsed().as_micros() as u64,
-                            },
-                        );
-                    pointer.frame(state);
-                    state.needs_redraw = true;
-                }
-            }
             _ => {}
             };
 

--- a/crates/emskin/src/winit.rs
+++ b/crates/emskin/src/winit.rs
@@ -556,6 +556,26 @@ pub fn init_winit(
                 }
                 state.needs_redraw = true;
             }
+            WinitEvent::DeviceEvent(winit_crate::event::DeviceEvent::MouseMotion {
+                delta: (dx, dy),
+            }) if state.cursor.host_cursor_locked => {
+                if let Some(pointer) = state.seat.get_pointer() {
+                    let focus = pointer
+                        .current_focus()
+                        .map(|surface| (surface, pointer.current_location()));
+                    pointer.relative_motion(
+                        state,
+                        focus,
+                        &smithay::input::pointer::RelativeMotionEvent {
+                            delta: (dx, dy).into(),
+                            delta_unaccel: (dx, dy).into(),
+                            utime: state.start_time.elapsed().as_micros() as u64,
+                        },
+                    );
+                    pointer.frame(state);
+                    state.needs_redraw = true;
+                }
+            }
             _ => {}
             };
 

--- a/crates/emskin/src/winit.rs
+++ b/crates/emskin/src/winit.rs
@@ -558,24 +558,22 @@ pub fn init_winit(
             }
             WinitEvent::DeviceEvent(winit_crate::event::DeviceEvent::MouseMotion {
                 delta: (dx, dy),
-            }) => {
-                if state.cursor.host_cursor_locked {
-                    if let Some(pointer) = state.seat.get_pointer() {
-                        let focus = pointer
-                            .current_focus()
-                            .map(|surface| (surface, pointer.current_location()));
-                        pointer.relative_motion(
-                            state,
-                            focus,
+            }) if state.cursor.host_cursor_locked => {
+                if let Some(pointer) = state.seat.get_pointer() {
+                    let focus = pointer
+                        .current_focus()
+                        .map(|surface| (surface, pointer.current_location()));
+                    pointer.relative_motion(
+                        state,
+                        focus,
                             &smithay::input::pointer::RelativeMotionEvent {
                                 delta: (dx, dy).into(),
                                 delta_unaccel: (dx, dy).into(),
                                 utime: state.start_time.elapsed().as_micros() as u64,
                             },
                         );
-                        pointer.frame(state);
-                        state.needs_redraw = true;
-                    }
+                    pointer.frame(state);
+                    state.needs_redraw = true;
                 }
             }
             _ => {}

--- a/crates/emskin/src/winit.rs
+++ b/crates/emskin/src/winit.rs
@@ -552,11 +552,35 @@ pub fn init_winit(
                             }
                         }
                     } else {
-                        state.on_focus_leave();
-                    }
-                    state.needs_redraw = true;
+                    state.on_focus_leave();
                 }
+                state.needs_redraw = true;
+            }
+            WinitEvent::DeviceEvent(winit_crate::event::DeviceEvent::MouseMotion {
+                delta: (dx, dy),
+            }) => {
+                if state.cursor.host_cursor_locked {
+                    if let Some(pointer) = state.seat.get_pointer() {
+                        let focus = pointer
+                            .current_focus()
+                            .map(|surface| (surface, pointer.current_location()));
+                        pointer.relative_motion(
+                            state,
+                            focus,
+                            &smithay::input::pointer::RelativeMotionEvent {
+                                delta: (dx, dy).into(),
+                                delta_unaccel: (dx, dy).into(),
+                                utime: state.start_time.elapsed().as_micros() as u64,
+                            },
+                        );
+                        pointer.frame(state);
+                        state.needs_redraw = true;
+                    }
+                }
+            }
+            _ => {}
             };
+
             state.backend = Some(backend);
         })?;
 


### PR DESCRIPTION
Summary

When an embedded game requests a locked pointer constraint, request CursorGrabMode::Locked on the winit window from the host compositor. This prevents the cursor from leaving emskin and enables infinite mouse rotation for FPS games.

Changes

pointer_constraints.rs — When a Locked constraint is activated, immediately request CursorGrabMode::Locked on the winit window.

input.rs — During pointer lock, warp the host cursor to window center each frame via set_cursor_position() and update last_raw_loc so the next delta reflects pure user movement.

cursor.rs — Added host_cursor_locked flag and force_raw_location(pos) for clean delta tracking after warps.

winit.rs — Forward DeviceEvent::MouseMotion (dx, dy) as pointer.relative_motion() to the embedded client during lock. This is the data path during CursorGrabMode::Locked since the host stops sending absolute position events.

tick.rs — Safety check: if host_cursor_locked is true but no active locked constraint exists, release the grab. Prevents permanent cursor lock after game exit without motion events.

Cargo.toml / smithay-local/ — Local smithay patch adding DeviceEvent to WinitEvent + device_event() on ApplicationHandler. Requires three lines in backend/winit/mod.rs.