### PR TITLE
fix: propagate fractional scale to embedded clients

### DIFF
--- a/crates/emskin/src/handlers/compositor.rs
+++ b/crates/emskin/src/handlers/compositor.rs
@@ -6,6 +6,7 @@ use smithay::{
     backend::renderer::utils::on_commit_buffer_handler,
     delegate_compositor, delegate_shm,
     desktop::{layer_map_for_output, utils::send_frames_surface_tree, WindowSurfaceType},
+    output::Output,
     reexports::wayland_server::{
         protocol::{wl_buffer, wl_surface::WlSurface},
         Client,
@@ -13,14 +14,59 @@ use smithay::{
     wayland::{
         buffer::BufferHandler,
         compositor::{
-            get_parent, is_sync_subsurface, CompositorClientState, CompositorHandler,
-            CompositorState,
+            get_parent, is_sync_subsurface, send_surface_state, with_states, CompositorClientState,
+            CompositorHandler, CompositorState, SurfaceData,
         },
+        fractional_scale::with_fractional_scale,
         shm::{ShmHandler, ShmState},
     },
 };
 
 use super::xdg_shell;
+
+/// Send the output's integer and fractional scale to one surface.
+///
+/// `preferred_buffer_scale` keeps wl_compositor-v6 clients working, while
+/// `wp_fractional_scale_v1.preferred_scale` lets modern clients render at the
+/// host compositor's exact fractional scale instead of rendering at the next
+/// integer scale and being downsampled.
+pub(crate) fn send_scale_transform(surface: &WlSurface, data: &SurfaceData, output: &Output) {
+    let scale = output.current_scale();
+    send_surface_state(
+        surface,
+        data,
+        scale.integer_scale(),
+        output.current_transform(),
+    );
+    with_fractional_scale(data, |fractional_scale| {
+        fractional_scale.set_preferred_scale(scale.fractional_scale());
+    });
+}
+
+impl EmskinState {
+    /// Re-send scale state to every mapped client after the host scale changes.
+    pub(crate) fn refresh_surface_scales(&self, output: &Output) {
+        for window in self.workspace.active_space.elements() {
+            window.with_surfaces(|surface, data| {
+                send_scale_transform(surface, data, output);
+            });
+        }
+        for workspace in self.workspace.inactive.values() {
+            for window in workspace.space.elements() {
+                window.with_surfaces(|surface, data| {
+                    send_scale_transform(surface, data, output);
+                });
+            }
+        }
+
+        let map = layer_map_for_output(output);
+        for layer in map.layers() {
+            layer.with_surfaces(|surface, data| {
+                send_scale_transform(surface, data, output);
+            });
+        }
+    }
+}
 
 impl CompositorHandler for EmskinState {
     fn compositor_state(&mut self) -> &mut CompositorState {
@@ -32,6 +78,14 @@ impl CompositorHandler for EmskinState {
             .get_data::<ClientState>()
             .expect("ClientState missing — client was not inserted via our listener")
             .compositor_state
+    }
+
+    fn new_subsurface(&mut self, surface: &WlSurface, _parent: &WlSurface) {
+        if let Some(output) = self.workspace.active_space.outputs().next() {
+            with_states(surface, |data| {
+                send_scale_transform(surface, data, output);
+            });
+        }
     }
 
     fn commit(&mut self, surface: &WlSurface) {
@@ -185,10 +239,12 @@ delegate_shm!(EmskinState);
 
 smithay::delegate_viewporter!(EmskinState);
 impl smithay::wayland::fractional_scale::FractionalScaleHandler for EmskinState {
-    fn new_fractional_scale(
-        &mut self,
-        _surface: smithay::reexports::wayland_server::protocol::wl_surface::WlSurface,
-    ) {
+    fn new_fractional_scale(&mut self, surface: WlSurface) {
+        if let Some(output) = self.workspace.active_space.outputs().next() {
+            with_states(&surface, |data| {
+                send_scale_transform(&surface, data, output);
+            });
+        }
     }
 }
 smithay::delegate_fractional_scale!(EmskinState);

--- a/crates/emskin/src/handlers/layer_shell.rs
+++ b/crates/emskin/src/handlers/layer_shell.rs
@@ -28,6 +28,17 @@ impl WlrLayerShellHandler for EmskinState {
             return;
         };
 
+        smithay::wayland::compositor::with_states(
+            desktop_layer.layer_surface().wl_surface(),
+            |data| {
+                super::compositor::send_scale_transform(
+                    desktop_layer.layer_surface().wl_surface(),
+                    data,
+                    &output,
+                );
+            },
+        );
+
         let mut map = layer_map_for_output(&output);
         let zone_before = map.non_exclusive_zone();
         if let Err(e) = map.map_layer(&desktop_layer) {

--- a/crates/emskin/src/handlers/xdg_shell.rs
+++ b/crates/emskin/src/handlers/xdg_shell.rs
@@ -27,6 +27,12 @@ impl XdgShellHandler for EmskinState {
     }
 
     fn new_toplevel(&mut self, surface: ToplevelSurface) {
+        if let Some(output) = self.workspace.active_space.outputs().next() {
+            with_states(surface.wl_surface(), |data| {
+                super::compositor::send_scale_transform(surface.wl_surface(), data, output);
+            });
+        }
+
         if self.emacs.should_claim_main() {
             // First toplevel = Emacs (Wayland/pgtk path only).
             // X11 Emacs sets initial_size_settled in map_window_request.
@@ -135,6 +141,11 @@ impl XdgShellHandler for EmskinState {
     }
 
     fn new_popup(&mut self, surface: PopupSurface, _positioner: PositionerState) {
+        if let Some(output) = self.workspace.active_space.outputs().next() {
+            with_states(surface.wl_surface(), |data| {
+                super::compositor::send_scale_transform(surface.wl_surface(), data, output);
+            });
+        }
         self.unconstrain_popup(&surface);
         if let Err(e) = self.wl.popups.track_popup(PopupKind::Xdg(surface)) {
             tracing::warn!("Failed to track popup: {}", e);

--- a/crates/emskin/src/state/mod.rs
+++ b/crates/emskin/src/state/mod.rs
@@ -265,7 +265,9 @@ impl EmskinState {
         let start_time = std::time::Instant::now();
         let dh = display.handle();
 
-        let compositor_state = CompositorState::new::<Self>(&dh);
+        // Version 6 lets us send preferred_buffer_scale to clients that do
+        // not bind wp-fractional-scale-v1.
+        let compositor_state = CompositorState::new_v6::<Self>(&dh);
         let xdg_shell_state = XdgShellState::new::<Self>(&dh);
         let shm_state = ShmState::new::<Self>(&dh, vec![]);
         let popups = PopupManager::default();

--- a/crates/emskin/src/winit.rs
+++ b/crates/emskin/src/winit.rs
@@ -432,6 +432,7 @@ pub fn init_winit(
                         Some(Scale::Fractional(scale_factor)),
                         None,
                     );
+                    state.refresh_surface_scales(&output);
                     // LayerMap caches `non_exclusive_zone` inside its `zone`
                     // field — it only refreshes when `arrange()` runs. Without
                     // this call, effects and Emacs would keep seeing the old

--- a/crates/emskin/tests/e2e_fractional_scale.rs
+++ b/crates/emskin/tests/e2e_fractional_scale.rs
@@ -1,0 +1,109 @@
+//! End-to-end coverage for wp-fractional-scale-v1 propagation.
+
+mod common;
+
+use std::os::unix::net::UnixStream;
+use std::time::Duration;
+
+use common::Compositor;
+use wayland_client::protocol::{wl_compositor, wl_registry, wl_surface};
+use wayland_client::{Connection, Dispatch, QueueHandle};
+use wayland_protocols::wp::fractional_scale::v1::client::{
+    wp_fractional_scale_manager_v1, wp_fractional_scale_v1,
+};
+
+#[derive(Default)]
+struct ClientState {
+    compositor: Option<wl_compositor::WlCompositor>,
+    compositor_version: Option<u32>,
+    fractional_scale_manager: Option<wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1>,
+    preferred_scale: Option<u32>,
+}
+
+impl Dispatch<wl_registry::WlRegistry, ()> for ClientState {
+    fn event(
+        state: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let wl_registry::Event::Global {
+            name,
+            interface,
+            version,
+        } = event
+        {
+            match interface.as_str() {
+                "wl_compositor" if state.compositor.is_none() => {
+                    state.compositor_version = Some(version);
+                    state.compositor = Some(registry.bind(name, version.min(6), qh, ()));
+                }
+                "wp_fractional_scale_manager_v1" if state.fractional_scale_manager.is_none() => {
+                    state.fractional_scale_manager =
+                        Some(registry.bind(name, version.min(1), qh, ()));
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+wayland_client::delegate_noop!(ClientState: ignore wl_compositor::WlCompositor);
+wayland_client::delegate_noop!(ClientState: ignore wl_surface::WlSurface);
+wayland_client::delegate_noop!(ClientState: wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1);
+
+impl Dispatch<wp_fractional_scale_v1::WpFractionalScaleV1, ()> for ClientState {
+    fn event(
+        state: &mut Self,
+        _: &wp_fractional_scale_v1::WpFractionalScaleV1,
+        event: wp_fractional_scale_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let wp_fractional_scale_v1::Event::PreferredScale { scale } = event {
+            state.preferred_scale = Some(scale);
+        }
+    }
+}
+
+#[test]
+fn surface_receives_the_output_preferred_scale() {
+    let compositor = Compositor::spawn();
+    compositor.wait_for_emskin_wayland_socket(Duration::from_secs(10));
+
+    let socket = compositor
+        .xdg_runtime_dir()
+        .join(compositor.emskin_wayland());
+    let connection = Connection::from_socket(UnixStream::connect(socket).unwrap()).unwrap();
+    let mut queue = connection.new_event_queue::<ClientState>();
+    let qh = queue.handle();
+    let _registry = connection.display().get_registry(&qh, ());
+    let mut state = ClientState::default();
+
+    queue.roundtrip(&mut state).unwrap();
+    assert_eq!(
+        state.compositor_version,
+        Some(6),
+        "emskin must advertise wl_compositor v6"
+    );
+    let wl_surface = state
+        .compositor
+        .as_ref()
+        .expect("emskin did not advertise wl_compositor")
+        .create_surface(&qh, ());
+    let _fractional_scale = state
+        .fractional_scale_manager
+        .as_ref()
+        .expect("emskin did not advertise wp-fractional-scale-v1")
+        .get_fractional_scale(&wl_surface, &qh, ());
+
+    queue.roundtrip(&mut state).unwrap();
+    assert_eq!(
+        state.preferred_scale,
+        Some(120),
+        "the 1x test output must be announced as 120/120"
+    );
+}


### PR DESCRIPTION
## Summary

- advertise `wl_compositor` v6 so clients can receive integer preferred buffer scales
- send the exact `wp_fractional_scale_v1` preferred scale to toplevels, popups, subsurfaces, and layer surfaces
- refresh scale state for mapped surfaces when the host output scale changes
- add an end-to-end Wayland protocol regression test

## Why

At fractional host scales such as 1.5x, emskin advertised the fractional-scale protocol but left its handler empty. Embedded clients therefore did not receive `preferred_scale`, so applications such as Firefox could render at an integer scale and then be downsampled, producing blurry text.

Subsurfaces are covered explicitly because browsers can create their fractional-scale objects on subsurfaces rather than only on the main toplevel.

## Tests

- `cargo fmt --all --check`
- `cargo check -p emskin --tests`
- `cargo build --workspace`
- `cargo test -p emskin --test e2e_fractional_scale`
- `cargo clippy --workspace -- -D warnings -A clippy::collapsible-match` (the allow is for a pre-existing warning in `crates/emskin/src/tick.rs` emitted by local Clippy 1.97)